### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/github-actions-updater.yaml
+++ b/.github/workflows/github-actions-updater.yaml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v3.5.2
                 with:
                     token: ${{ secrets.GH_TOKEN_WORKFLOW }}
             -

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,17 +14,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v3.5.2
             -
-                uses: docker/setup-buildx-action@v2
+                uses: docker/setup-buildx-action@v2.5.0
             -
-                uses: docker/login-action@v2
+                uses: docker/login-action@v2.1.0
                 with:
                     username: ${{ secrets.DOCKER_HUB_USERNAME }}
                     password: ${{ secrets.DOCKER_HUB_PASSWORD }}
             -
                 id: meta
-                uses: docker/metadata-action@v4
+                uses: docker/metadata-action@v4.4.0
                 with:
                     images: ${{ env.DOCKER_IMAGE }}
             -

--- a/.github/workflows/quality-assurance.yaml
+++ b/.github/workflows/quality-assurance.yaml
@@ -11,6 +11,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v3.5.2
             -
                 run: make lint


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.5.0](https://github.com/docker/setup-buildx-action/releases/tag/v2.5.0)** on 2023-03-10T09:47:20Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v2.1.0](https://github.com/docker/login-action/releases/tag/v2.1.0)** on 2022-10-12T07:04:14Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v4.4.0](https://github.com/docker/metadata-action/releases/tag/v4.4.0)** on 2023-04-18T07:31:37Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** on 2023-04-13T12:49:40Z
